### PR TITLE
Bump WebdriverIO dependencies to fix ChromeDriver download URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@wdio/cli": "^8.32.3",
         "@wdio/local-runner": "^8.32.3",
         "@wdio/mocha-framework": "^8.32.3",
-        "@wdio/spec-reporter": "^8.27.0",
+        "@wdio/spec-reporter": "^8.32.2",
         "@wdio/types": "^8.27.0",
         "eslint": "^8.56.0",
         "eslint-config-airbnb-base": "^15.0.0",
@@ -2223,18 +2223,6 @@
         "node": "^16.13 || >=18"
       }
     },
-    "node_modules/@wdio/cli/node_modules/@wdio/types": {
-      "version": "8.32.2",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.32.2.tgz",
-      "integrity": "sha512-jq8LcBBQpBP9ZF5kECKEpXv8hN7irCGCjLFAN0Bd5ScRR6qu6MGWvwkDkau2sFPr0b++sKDCEaMzQlwrGFjZXg==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "^20.1.0"
-      },
-      "engines": {
-        "node": "^16.13 || >=18"
-      }
-    },
     "node_modules/@wdio/cli/node_modules/execa": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
@@ -2308,17 +2296,6 @@
         "node": "^16.13 || >=18"
       }
     },
-    "node_modules/@wdio/config/node_modules/@wdio/types": {
-      "version": "8.32.2",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.32.2.tgz",
-      "integrity": "sha512-jq8LcBBQpBP9ZF5kECKEpXv8hN7irCGCjLFAN0Bd5ScRR6qu6MGWvwkDkau2sFPr0b++sKDCEaMzQlwrGFjZXg==",
-      "dependencies": {
-        "@types/node": "^20.1.0"
-      },
-      "engines": {
-        "node": "^16.13 || >=18"
-      }
-    },
     "node_modules/@wdio/globals": {
       "version": "8.32.3",
       "resolved": "https://registry.npmjs.org/@wdio/globals/-/globals-8.32.3.tgz",
@@ -2346,18 +2323,6 @@
         "async-exit-hook": "^2.0.1",
         "split2": "^4.1.0",
         "stream-buffers": "^3.0.2"
-      },
-      "engines": {
-        "node": "^16.13 || >=18"
-      }
-    },
-    "node_modules/@wdio/local-runner/node_modules/@wdio/types": {
-      "version": "8.32.2",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.32.2.tgz",
-      "integrity": "sha512-jq8LcBBQpBP9ZF5kECKEpXv8hN7irCGCjLFAN0Bd5ScRR6qu6MGWvwkDkau2sFPr0b++sKDCEaMzQlwrGFjZXg==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "^20.1.0"
       },
       "engines": {
         "node": "^16.13 || >=18"
@@ -2394,18 +2359,6 @@
         "node": "^16.13 || >=18"
       }
     },
-    "node_modules/@wdio/mocha-framework/node_modules/@wdio/types": {
-      "version": "8.32.2",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.32.2.tgz",
-      "integrity": "sha512-jq8LcBBQpBP9ZF5kECKEpXv8hN7irCGCjLFAN0Bd5ScRR6qu6MGWvwkDkau2sFPr0b++sKDCEaMzQlwrGFjZXg==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "^20.1.0"
-      },
-      "engines": {
-        "node": "^16.13 || >=18"
-      }
-    },
     "node_modules/@wdio/protocols": {
       "version": "8.32.0",
       "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-8.32.0.tgz",
@@ -2423,14 +2376,14 @@
       }
     },
     "node_modules/@wdio/reporter": {
-      "version": "8.31.1",
-      "resolved": "https://registry.npmjs.org/@wdio/reporter/-/reporter-8.31.1.tgz",
-      "integrity": "sha512-ayZipzyr9dSwpbKYbV4PoXuw91A1H7fjadJ5R5oMYUETx+pfBJqjR2UIHZhhPAa0lJ7bWHEn7eCsGB1PXp47Og==",
+      "version": "8.32.2",
+      "resolved": "https://registry.npmjs.org/@wdio/reporter/-/reporter-8.32.2.tgz",
+      "integrity": "sha512-BZdReAFfRCtgtYbyhkKgSGqqoIn/yG5/Z4COjvRvon9NJkz+eA4PiHCKdEP7+ekBIjud7H8Gy+6mPBDEu+wllw==",
       "dev": true,
       "dependencies": {
         "@types/node": "^20.1.0",
         "@wdio/logger": "8.28.0",
-        "@wdio/types": "8.31.1",
+        "@wdio/types": "8.32.2",
         "diff": "^5.0.0",
         "object-inspect": "^1.12.0"
       },
@@ -2460,26 +2413,14 @@
         "node": "^16.13 || >=18"
       }
     },
-    "node_modules/@wdio/runner/node_modules/@wdio/types": {
-      "version": "8.32.2",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.32.2.tgz",
-      "integrity": "sha512-jq8LcBBQpBP9ZF5kECKEpXv8hN7irCGCjLFAN0Bd5ScRR6qu6MGWvwkDkau2sFPr0b++sKDCEaMzQlwrGFjZXg==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "^20.1.0"
-      },
-      "engines": {
-        "node": "^16.13 || >=18"
-      }
-    },
     "node_modules/@wdio/spec-reporter": {
-      "version": "8.31.1",
-      "resolved": "https://registry.npmjs.org/@wdio/spec-reporter/-/spec-reporter-8.31.1.tgz",
-      "integrity": "sha512-t2isqf/yDvc3xfNnkuR8XdRaKf34I6/40f1DHfojHZUpTF94jrt7CLACkFiDZhu5sz0KCuDWzy56aycd6IUz3w==",
+      "version": "8.32.2",
+      "resolved": "https://registry.npmjs.org/@wdio/spec-reporter/-/spec-reporter-8.32.2.tgz",
+      "integrity": "sha512-3hUXpE+idC4KOXofJnpubdDDCE8X0OTd6ykypiaXMI2hJTA2nIZcHtpRQnAE0E4JT9OzLnPWODcMq54GGBDRkg==",
       "dev": true,
       "dependencies": {
-        "@wdio/reporter": "8.31.1",
-        "@wdio/types": "8.31.1",
+        "@wdio/reporter": "8.32.2",
+        "@wdio/types": "8.32.2",
         "chalk": "^5.1.2",
         "easy-table": "^1.2.0",
         "pretty-ms": "^7.0.0"
@@ -2489,10 +2430,9 @@
       }
     },
     "node_modules/@wdio/types": {
-      "version": "8.31.1",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.31.1.tgz",
-      "integrity": "sha512-KQ0EmjeVdshufhsxygaPzkJ8WD7hm8WlflZcLwKMZ0OM6f8pV9NMGGOvfBQXgTs447ScK6/6rX+lbJk3yvg65g==",
-      "dev": true,
+      "version": "8.32.2",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.32.2.tgz",
+      "integrity": "sha512-jq8LcBBQpBP9ZF5kECKEpXv8hN7irCGCjLFAN0Bd5ScRR6qu6MGWvwkDkau2sFPr0b++sKDCEaMzQlwrGFjZXg==",
       "dependencies": {
         "@types/node": "^20.1.0"
       },
@@ -2541,17 +2481,6 @@
       },
       "engines": {
         "node": ">=16.3.0"
-      }
-    },
-    "node_modules/@wdio/utils/node_modules/@wdio/types": {
-      "version": "8.32.2",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.32.2.tgz",
-      "integrity": "sha512-jq8LcBBQpBP9ZF5kECKEpXv8hN7irCGCjLFAN0Bd5ScRR6qu6MGWvwkDkau2sFPr0b++sKDCEaMzQlwrGFjZXg==",
-      "dependencies": {
-        "@types/node": "^20.1.0"
-      },
-      "engines": {
-        "node": "^16.13 || >=18"
       }
     },
     "node_modules/@wdio/utils/node_modules/lru-cache": {
@@ -11903,17 +11832,6 @@
         "node": "^16.13 || >=18"
       }
     },
-    "node_modules/webdriver/node_modules/@wdio/types": {
-      "version": "8.32.2",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.32.2.tgz",
-      "integrity": "sha512-jq8LcBBQpBP9ZF5kECKEpXv8hN7irCGCjLFAN0Bd5ScRR6qu6MGWvwkDkau2sFPr0b++sKDCEaMzQlwrGFjZXg==",
-      "dependencies": {
-        "@types/node": "^20.1.0"
-      },
-      "engines": {
-        "node": "^16.13 || >=18"
-      }
-    },
     "node_modules/webdriver/node_modules/got": {
       "version": "12.6.1",
       "resolved": "https://registry.npmjs.org/got/-/got-12.6.1.tgz",
@@ -11978,17 +11896,6 @@
         "devtools": {
           "optional": true
         }
-      }
-    },
-    "node_modules/webdriverio/node_modules/@wdio/types": {
-      "version": "8.32.2",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.32.2.tgz",
-      "integrity": "sha512-jq8LcBBQpBP9ZF5kECKEpXv8hN7irCGCjLFAN0Bd5ScRR6qu6MGWvwkDkau2sFPr0b++sKDCEaMzQlwrGFjZXg==",
-      "dependencies": {
-        "@types/node": "^20.1.0"
-      },
-      "engines": {
-        "node": "^16.13 || >=18"
       }
     },
     "node_modules/webdriverio/node_modules/brace-expansion": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@types/node": "^20.10.5",
         "@typescript-eslint/eslint-plugin": "^6.16.0",
         "@typescript-eslint/parser": "^6.16.0",
-        "@wdio/cli": "^8.27.0",
+        "@wdio/cli": "^8.32.3",
         "@wdio/local-runner": "^8.27.0",
         "@wdio/mocha-framework": "^8.27.0",
         "@wdio/spec-reporter": "^8.27.0",
@@ -1582,9 +1582,9 @@
       }
     },
     "node_modules/@types/normalize-package-data": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
-      "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+      "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "dev": true
     },
     "node_modules/@types/semver": {
@@ -2186,19 +2186,19 @@
       }
     },
     "node_modules/@wdio/cli": {
-      "version": "8.31.1",
-      "resolved": "https://registry.npmjs.org/@wdio/cli/-/cli-8.31.1.tgz",
-      "integrity": "sha512-UnAoXjUrgRTfFq7TSnnMSuA80V8G7yW/d5zo59RtzrHdrGr6QVWJfnt6aLueXJJ6SnouVA6yU2rcsXPOvGpUIA==",
+      "version": "8.32.3",
+      "resolved": "https://registry.npmjs.org/@wdio/cli/-/cli-8.32.3.tgz",
+      "integrity": "sha512-qjR1MFKQM547iCooceBHyggJRNguD7fhgF4Q7L2r7psG3AQFWzdCN/8rulRGIxTz4PJlIqks9AH9kUJlVAf44A==",
       "dev": true,
       "dependencies": {
         "@types/node": "^20.1.1",
         "@vitest/snapshot": "^1.2.1",
-        "@wdio/config": "8.31.1",
-        "@wdio/globals": "8.31.1",
+        "@wdio/config": "8.32.3",
+        "@wdio/globals": "8.32.3",
         "@wdio/logger": "8.28.0",
-        "@wdio/protocols": "8.29.7",
-        "@wdio/types": "8.31.1",
-        "@wdio/utils": "8.31.1",
+        "@wdio/protocols": "8.32.0",
+        "@wdio/types": "8.32.2",
+        "@wdio/utils": "8.32.3",
         "async-exit-hook": "^2.0.1",
         "chalk": "^5.2.0",
         "chokidar": "^3.5.3",
@@ -2207,13 +2207,13 @@
         "ejs": "^3.1.9",
         "execa": "^8.0.1",
         "import-meta-resolve": "^4.0.0",
-        "inquirer": "9.2.14",
+        "inquirer": "9.2.12",
         "lodash.flattendeep": "^4.4.0",
         "lodash.pickby": "^4.6.0",
         "lodash.union": "^4.6.0",
-        "read-pkg-up": "^10.0.0",
+        "read-pkg-up": "10.0.0",
         "recursive-readdir": "^2.2.3",
-        "webdriverio": "8.31.1",
+        "webdriverio": "8.32.3",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -2223,13 +2223,107 @@
         "node": "^16.13 || >=18"
       }
     },
-    "node_modules/@wdio/cli/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+    "node_modules/@wdio/cli/node_modules/@puppeteer/browsers": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.9.1.tgz",
+      "integrity": "sha512-PuvK6xZzGhKPvlx3fpfdM2kYY3P/hB1URtK8wA7XUJ6prn6pp22zvJHu48th0SGcHL9SutbPHrFuQgfXTFobWA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "4.3.4",
+        "extract-zip": "2.0.1",
+        "progress": "2.0.3",
+        "proxy-agent": "6.3.1",
+        "tar-fs": "3.0.4",
+        "unbzip2-stream": "1.4.3",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=16.3.0"
+      }
+    },
+    "node_modules/@wdio/cli/node_modules/@wdio/config": {
+      "version": "8.32.3",
+      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-8.32.3.tgz",
+      "integrity": "sha512-hZkaz5Fd8830uniQvRgPus8yp9rp50MAsHa5kZ2Jt8y++Rp330FyJpQZE5oPjTATuz35G5Anprk2Q3fmFd0Ifw==",
+      "dev": true,
+      "dependencies": {
+        "@wdio/logger": "8.28.0",
+        "@wdio/types": "8.32.2",
+        "@wdio/utils": "8.32.3",
+        "decamelize": "^6.0.0",
+        "deepmerge-ts": "^5.0.0",
+        "glob": "^10.2.2",
+        "import-meta-resolve": "^4.0.0"
+      },
+      "engines": {
+        "node": "^16.13 || >=18"
+      }
+    },
+    "node_modules/@wdio/cli/node_modules/@wdio/globals": {
+      "version": "8.32.3",
+      "resolved": "https://registry.npmjs.org/@wdio/globals/-/globals-8.32.3.tgz",
+      "integrity": "sha512-jyK89GvWaOYQT9pfZ6HNwkFANgai9eBVfeDPw5yFLXfk6js9GSWbvqMJg/PFi1dQ7xbnbuuf5eYVc65bfAt9KQ==",
       "dev": true,
       "engines": {
-        "node": ">=0.8.0"
+        "node": "^16.13 || >=18"
+      },
+      "optionalDependencies": {
+        "expect-webdriverio": "^4.11.2",
+        "webdriverio": "8.32.3"
+      }
+    },
+    "node_modules/@wdio/cli/node_modules/@wdio/protocols": {
+      "version": "8.32.0",
+      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-8.32.0.tgz",
+      "integrity": "sha512-inLJRrtIGdTz/YPbcsvpSvPlYQFTVtF3OYBwAXhG2FiP1ZwE1CQNLP/xgRGye1ymdGCypGkexRqIx3KBGm801Q==",
+      "dev": true
+    },
+    "node_modules/@wdio/cli/node_modules/@wdio/types": {
+      "version": "8.32.2",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.32.2.tgz",
+      "integrity": "sha512-jq8LcBBQpBP9ZF5kECKEpXv8hN7irCGCjLFAN0Bd5ScRR6qu6MGWvwkDkau2sFPr0b++sKDCEaMzQlwrGFjZXg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "^20.1.0"
+      },
+      "engines": {
+        "node": "^16.13 || >=18"
+      }
+    },
+    "node_modules/@wdio/cli/node_modules/@wdio/utils": {
+      "version": "8.32.3",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-8.32.3.tgz",
+      "integrity": "sha512-UnR9rPpR1W9U5wz2TU+6BQ2rlxtuK/e3fvdaiWIMZKleB/OCcEQFGiGPAGGVi4ShfaTPwz6hK1cTTgj1OtMXkg==",
+      "dev": true,
+      "dependencies": {
+        "@puppeteer/browsers": "^1.6.0",
+        "@wdio/logger": "8.28.0",
+        "@wdio/types": "8.32.2",
+        "decamelize": "^6.0.0",
+        "deepmerge-ts": "^5.1.0",
+        "edgedriver": "^5.3.5",
+        "geckodriver": "^4.3.1",
+        "get-port": "^7.0.0",
+        "import-meta-resolve": "^4.0.0",
+        "locate-app": "^2.1.0",
+        "safaridriver": "^0.1.0",
+        "split2": "^4.2.0",
+        "wait-port": "^1.0.4"
+      },
+      "engines": {
+        "node": "^16.13 || >=18"
+      }
+    },
+    "node_modules/@wdio/cli/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@wdio/cli/node_modules/execa": {
@@ -2255,21 +2349,6 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
-    "node_modules/@wdio/cli/node_modules/figures": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-      "dev": true,
-      "dependencies": {
-        "escape-string-regexp": "^1.0.5"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@wdio/cli/node_modules/get-stream": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
@@ -2277,6 +2356,43 @@
       "dev": true,
       "engines": {
         "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@wdio/cli/node_modules/got": {
+      "version": "12.6.1",
+      "resolved": "https://registry.npmjs.org/got/-/got-12.6.1.tgz",
+      "integrity": "sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==",
+      "dev": true,
+      "dependencies": {
+        "@sindresorhus/is": "^5.2.0",
+        "@szmarczak/http-timer": "^5.0.1",
+        "cacheable-lookup": "^7.0.0",
+        "cacheable-request": "^10.2.8",
+        "decompress-response": "^6.0.0",
+        "form-data-encoder": "^2.1.2",
+        "get-stream": "^6.0.1",
+        "http2-wrapper": "^2.1.10",
+        "lowercase-keys": "^3.0.0",
+        "p-cancelable": "^3.0.0",
+        "responselike": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/@wdio/cli/node_modules/got/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2291,30 +2407,47 @@
         "node": ">=16.17.0"
       }
     },
-    "node_modules/@wdio/cli/node_modules/inquirer": {
-      "version": "9.2.14",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-9.2.14.tgz",
-      "integrity": "sha512-4ByIMt677Iz5AvjyKrDpzaepIyMewNvDcvwpVVRZNmy9dLakVoVgdCHZXbK1SlVJra1db0JZ6XkJyHsanpdrdQ==",
+    "node_modules/@wdio/cli/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wdio/cli/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
       "dev": true,
       "dependencies": {
-        "@ljharb/through": "^2.3.12",
-        "ansi-escapes": "^4.3.2",
-        "chalk": "^5.3.0",
-        "cli-cursor": "^3.1.0",
-        "cli-width": "^4.1.0",
-        "external-editor": "^3.1.0",
-        "figures": "^3.2.0",
-        "lodash": "^4.17.21",
-        "mute-stream": "1.0.0",
-        "ora": "^5.4.1",
-        "run-async": "^3.0.0",
-        "rxjs": "^7.8.1",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^6.2.0"
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@wdio/cli/node_modules/proxy-agent": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.1.tgz",
+      "integrity": "sha512-Rb5RVBy1iyqOtNl15Cw/llpeLH8bsb37gM1FUfKQ+Wck6xHlbAhWGUFiTRHtkjqGTA5pSHz6+0hrPW/oECihPQ==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.2",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.0.1",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/@wdio/cli/node_modules/signal-exit": {
@@ -2329,16 +2462,69 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@wdio/cli/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+    "node_modules/@wdio/cli/node_modules/webdriver": {
+      "version": "8.32.3",
+      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-8.32.3.tgz",
+      "integrity": "sha512-1/kpZvuftt59oikHs+6FvWXNfOM5tgMMMAk3LnMe7D938dVOoNGAe46fq0oL/xsxxPicbMRTRgIy1OifLiglaA==",
       "dev": true,
       "dependencies": {
-        "ansi-regex": "^5.0.1"
+        "@types/node": "^20.1.0",
+        "@types/ws": "^8.5.3",
+        "@wdio/config": "8.32.3",
+        "@wdio/logger": "8.28.0",
+        "@wdio/protocols": "8.32.0",
+        "@wdio/types": "8.32.2",
+        "@wdio/utils": "8.32.3",
+        "deepmerge-ts": "^5.1.0",
+        "got": "^12.6.1",
+        "ky": "^0.33.0",
+        "ws": "^8.8.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": "^16.13 || >=18"
+      }
+    },
+    "node_modules/@wdio/cli/node_modules/webdriverio": {
+      "version": "8.32.3",
+      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-8.32.3.tgz",
+      "integrity": "sha512-SupbQKMtUZHSH7lmF5xaJPgxsn8sIBNAjs1CyPI33u30eY9VcVQ4CJQ818ZS3FLxR0q2XdWk9lsQNyhZwlN3RA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "^20.1.0",
+        "@wdio/config": "8.32.3",
+        "@wdio/logger": "8.28.0",
+        "@wdio/protocols": "8.32.0",
+        "@wdio/repl": "8.24.12",
+        "@wdio/types": "8.32.2",
+        "@wdio/utils": "8.32.3",
+        "archiver": "^6.0.0",
+        "aria-query": "^5.0.0",
+        "css-shorthand-properties": "^1.1.1",
+        "css-value": "^0.0.1",
+        "devtools-protocol": "^0.0.1262051",
+        "grapheme-splitter": "^1.0.2",
+        "import-meta-resolve": "^4.0.0",
+        "is-plain-obj": "^4.1.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.zip": "^4.2.0",
+        "minimatch": "^9.0.0",
+        "puppeteer-core": "^20.9.0",
+        "query-selector-shadow-dom": "^1.0.0",
+        "resq": "^1.9.1",
+        "rgb2hex": "0.2.5",
+        "serialize-error": "^11.0.1",
+        "webdriver": "8.32.3"
+      },
+      "engines": {
+        "node": "^16.13 || >=18"
+      },
+      "peerDependencies": {
+        "devtools": "^8.14.0"
+      },
+      "peerDependenciesMeta": {
+        "devtools": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wdio/config": {
@@ -4137,10 +4323,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1249869",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1249869.tgz",
-      "integrity": "sha512-Ctp4hInA0BEavlUoRy9mhGq0i+JSo/AwVyX2EFgZmV1kYB+Zq+EMBAn52QWu6FbRr10hRb6pBl420upbp4++vg==",
-      "peer": true
+      "version": "0.0.1262051",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1262051.tgz",
+      "integrity": "sha512-YJe4CT5SA8on3Spa+UDtNhEqtuV6Epwz3OZ4HQVLhlRccpZ9/PAYk0/cy/oKxFKRrZPBUPyxympQci4yWNWZ9g=="
     },
     "node_modules/diff": {
       "version": "5.2.0",
@@ -9612,14 +9797,14 @@
       }
     },
     "node_modules/read-pkg-up": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-10.1.0.tgz",
-      "integrity": "sha512-aNtBq4jR8NawpKJQldrQcSW9y/d+KWH4v24HWkHljOZ7H0av+YTGANBzRh9A5pw7v/bLVsLVPpOhJ7gHNVy8lA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-10.0.0.tgz",
+      "integrity": "sha512-jgmKiS//w2Zs+YbX039CorlkOp8FIVbSAN8r8GJHDsGlmNPXo+VeHkqAwCiQVTTx5/LwLZTcEw59z3DvcLbr0g==",
       "dev": true,
       "dependencies": {
         "find-up": "^6.3.0",
-        "read-pkg": "^8.1.0",
-        "type-fest": "^4.2.0"
+        "read-pkg": "^8.0.0",
+        "type-fest": "^3.12.0"
       },
       "engines": {
         "node": ">=16"
@@ -9645,9 +9830,9 @@
       }
     },
     "node_modules/read-pkg-up/node_modules/hosted-git-info": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.0.tgz",
-      "integrity": "sha512-ICclEpTLhHj+zCuSb2/usoNXSVkxUSIopre+b1w8NDY9Dntp9LO4vLdHYI336TH8sAqwrRgnSfdkBG2/YpisHA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.1.tgz",
+      "integrity": "sha512-+K84LB1DYwMHoHSgaOY/Jfhw3ucPmSET5v98Ke/HdNSw4a0UktWzyW1mjhjpuxxTqOOsfWT/7iVshHmVZ4IpOA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^10.0.1"
@@ -9657,18 +9842,18 @@
       }
     },
     "node_modules/read-pkg-up/node_modules/json-parse-even-better-errors": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.0.tgz",
-      "integrity": "sha512-iZbGHafX/59r39gPwVPRBGw0QQKnA7tte5pSMrhWOW7swGsVvVTjmfyAV9pNqk8YGT7tRCdxRu8uzcgZwoDooA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.1.tgz",
+      "integrity": "sha512-aatBvbL26wVUCLmbWdCpeu9iF5wOyWpagiKkInA+kfws3sWdBrTnsvN2CKcyCYyUrc7rebNBlK6+kteg7ksecg==",
       "dev": true,
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/read-pkg-up/node_modules/lines-and-columns": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.3.tgz",
-      "integrity": "sha512-cNOjgCnLB+FnvWWtyRTzmB3POJ+cXxTA81LoW7u8JdmhfXzriropYwpjShnz1QLLWsQwY7nIxoDmcPTwphDK9w==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.4.tgz",
+      "integrity": "sha512-wM1+Z03eypVAVUCE7QdSqpVIvelbOakn1M0bPDoA4SGWPx3sNDVUiMo3L6To6WWGClB7VyXnhQ4Sn7gxiJbE6A==",
       "dev": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
@@ -9735,9 +9920,9 @@
       }
     },
     "node_modules/read-pkg-up/node_modules/parse-json": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-7.1.0.tgz",
-      "integrity": "sha512-ihtdrgbqdONYD156Ap6qTcaGcGdkdAxodO1wLqQ/j7HP1u2sFYppINiq4jyC8F+Nm+4fVufylCV00QmkTHkSUg==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-7.1.1.tgz",
+      "integrity": "sha512-SgOTCX/EZXtZxBE5eJ97P4yGM5n37BwRU+YMsH4vNzFqJV/oWFXXCmwFlgWUM4PrakybVOueJJ6pwHqSVhTFDw==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.21.4",
@@ -9748,18 +9933,6 @@
       },
       "engines": {
         "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/parse-json/node_modules/type-fest": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
-      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
-      "dev": true,
-      "engines": {
-        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -9792,13 +9965,25 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/read-pkg-up/node_modules/type-fest": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.3.1.tgz",
-      "integrity": "sha512-pphNW/msgOUSkJbH58x8sqpq8uQj6b0ZKGxEsLKMUnGorRcDjrUaLS+39+/ub41JNTwrrMyJcUB8+YZs3mbwqw==",
+    "node_modules/read-pkg-up/node_modules/read-pkg/node_modules/type-fest": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.10.2.tgz",
+      "integrity": "sha512-anpAG63wSpdEbLwOqH8L84urkL6PiVIov3EMmgIhhThevh9aiMQov+6Btx0wldNcvm4wV+e2/Rt1QdDwKHFbHw==",
       "dev": true,
       "engines": {
         "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/type-fest": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
+      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@typescript-eslint/parser": "^6.16.0",
         "@wdio/cli": "^8.32.3",
         "@wdio/local-runner": "^8.32.3",
-        "@wdio/mocha-framework": "^8.27.0",
+        "@wdio/mocha-framework": "^8.32.3",
         "@wdio/spec-reporter": "^8.27.0",
         "@wdio/types": "^8.27.0",
         "eslint": "^8.56.0",
@@ -2223,27 +2223,6 @@
         "node": "^16.13 || >=18"
       }
     },
-    "node_modules/@wdio/cli/node_modules/@puppeteer/browsers": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.9.1.tgz",
-      "integrity": "sha512-PuvK6xZzGhKPvlx3fpfdM2kYY3P/hB1URtK8wA7XUJ6prn6pp22zvJHu48th0SGcHL9SutbPHrFuQgfXTFobWA==",
-      "dev": true,
-      "dependencies": {
-        "debug": "4.3.4",
-        "extract-zip": "2.0.1",
-        "progress": "2.0.3",
-        "proxy-agent": "6.3.1",
-        "tar-fs": "3.0.4",
-        "unbzip2-stream": "1.4.3",
-        "yargs": "17.7.2"
-      },
-      "bin": {
-        "browsers": "lib/cjs/main-cli.js"
-      },
-      "engines": {
-        "node": ">=16.3.0"
-      }
-    },
     "node_modules/@wdio/cli/node_modules/@wdio/types": {
       "version": "8.32.2",
       "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.32.2.tgz",
@@ -2251,30 +2230,6 @@
       "dev": true,
       "dependencies": {
         "@types/node": "^20.1.0"
-      },
-      "engines": {
-        "node": "^16.13 || >=18"
-      }
-    },
-    "node_modules/@wdio/cli/node_modules/@wdio/utils": {
-      "version": "8.32.3",
-      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-8.32.3.tgz",
-      "integrity": "sha512-UnR9rPpR1W9U5wz2TU+6BQ2rlxtuK/e3fvdaiWIMZKleB/OCcEQFGiGPAGGVi4ShfaTPwz6hK1cTTgj1OtMXkg==",
-      "dev": true,
-      "dependencies": {
-        "@puppeteer/browsers": "^1.6.0",
-        "@wdio/logger": "8.28.0",
-        "@wdio/types": "8.32.2",
-        "decamelize": "^6.0.0",
-        "deepmerge-ts": "^5.1.0",
-        "edgedriver": "^5.3.5",
-        "geckodriver": "^4.3.1",
-        "get-port": "^7.0.0",
-        "import-meta-resolve": "^4.0.0",
-        "locate-app": "^2.1.0",
-        "safaridriver": "^0.1.0",
-        "split2": "^4.2.0",
-        "wait-port": "^1.0.4"
       },
       "engines": {
         "node": "^16.13 || >=18"
@@ -2324,34 +2279,6 @@
         "node": ">=16.17.0"
       }
     },
-    "node_modules/@wdio/cli/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@wdio/cli/node_modules/proxy-agent": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.1.tgz",
-      "integrity": "sha512-Rb5RVBy1iyqOtNl15Cw/llpeLH8bsb37gM1FUfKQ+Wck6xHlbAhWGUFiTRHtkjqGTA5pSHz6+0hrPW/oECihPQ==",
-      "dev": true,
-      "dependencies": {
-        "agent-base": "^7.0.2",
-        "debug": "^4.3.4",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.2",
-        "lru-cache": "^7.14.1",
-        "pac-proxy-agent": "^7.0.1",
-        "proxy-from-env": "^1.1.0",
-        "socks-proxy-agent": "^8.0.2"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/@wdio/cli/node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -2381,26 +2308,6 @@
         "node": "^16.13 || >=18"
       }
     },
-    "node_modules/@wdio/config/node_modules/@puppeteer/browsers": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.9.1.tgz",
-      "integrity": "sha512-PuvK6xZzGhKPvlx3fpfdM2kYY3P/hB1URtK8wA7XUJ6prn6pp22zvJHu48th0SGcHL9SutbPHrFuQgfXTFobWA==",
-      "dependencies": {
-        "debug": "4.3.4",
-        "extract-zip": "2.0.1",
-        "progress": "2.0.3",
-        "proxy-agent": "6.3.1",
-        "tar-fs": "3.0.4",
-        "unbzip2-stream": "1.4.3",
-        "yargs": "17.7.2"
-      },
-      "bin": {
-        "browsers": "lib/cjs/main-cli.js"
-      },
-      "engines": {
-        "node": ">=16.3.0"
-      }
-    },
     "node_modules/@wdio/config/node_modules/@wdio/types": {
       "version": "8.32.2",
       "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.32.2.tgz",
@@ -2410,55 +2317,6 @@
       },
       "engines": {
         "node": "^16.13 || >=18"
-      }
-    },
-    "node_modules/@wdio/config/node_modules/@wdio/utils": {
-      "version": "8.32.3",
-      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-8.32.3.tgz",
-      "integrity": "sha512-UnR9rPpR1W9U5wz2TU+6BQ2rlxtuK/e3fvdaiWIMZKleB/OCcEQFGiGPAGGVi4ShfaTPwz6hK1cTTgj1OtMXkg==",
-      "dependencies": {
-        "@puppeteer/browsers": "^1.6.0",
-        "@wdio/logger": "8.28.0",
-        "@wdio/types": "8.32.2",
-        "decamelize": "^6.0.0",
-        "deepmerge-ts": "^5.1.0",
-        "edgedriver": "^5.3.5",
-        "geckodriver": "^4.3.1",
-        "get-port": "^7.0.0",
-        "import-meta-resolve": "^4.0.0",
-        "locate-app": "^2.1.0",
-        "safaridriver": "^0.1.0",
-        "split2": "^4.2.0",
-        "wait-port": "^1.0.4"
-      },
-      "engines": {
-        "node": "^16.13 || >=18"
-      }
-    },
-    "node_modules/@wdio/config/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@wdio/config/node_modules/proxy-agent": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.1.tgz",
-      "integrity": "sha512-Rb5RVBy1iyqOtNl15Cw/llpeLH8bsb37gM1FUfKQ+Wck6xHlbAhWGUFiTRHtkjqGTA5pSHz6+0hrPW/oECihPQ==",
-      "dependencies": {
-        "agent-base": "^7.0.2",
-        "debug": "^4.3.4",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.2",
-        "lru-cache": "^7.14.1",
-        "pac-proxy-agent": "^7.0.1",
-        "proxy-from-env": "^1.1.0",
-        "socks-proxy-agent": "^8.0.2"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/@wdio/globals": {
@@ -2520,17 +2378,29 @@
       }
     },
     "node_modules/@wdio/mocha-framework": {
-      "version": "8.31.1",
-      "resolved": "https://registry.npmjs.org/@wdio/mocha-framework/-/mocha-framework-8.31.1.tgz",
-      "integrity": "sha512-5297tKj9zNvzZD+X4tMSuTcJrSaQ6mmDGLEdapa/+CMA549N+0vE38tNh+5Br7dmFXXVanw40T752OQcSeFf1A==",
+      "version": "8.32.3",
+      "resolved": "https://registry.npmjs.org/@wdio/mocha-framework/-/mocha-framework-8.32.3.tgz",
+      "integrity": "sha512-wwQ6rDd6TMPqwGfkwvtcBmcirYZUi9GUiwH2OsHvMJ4i+YY7H2dLyZon1ghcIan7r4ufr8KlljbwyerCpUzvcw==",
       "dev": true,
       "dependencies": {
         "@types/mocha": "^10.0.0",
         "@types/node": "^20.1.0",
         "@wdio/logger": "8.28.0",
-        "@wdio/types": "8.31.1",
-        "@wdio/utils": "8.31.1",
+        "@wdio/types": "8.32.2",
+        "@wdio/utils": "8.32.3",
         "mocha": "^10.0.0"
+      },
+      "engines": {
+        "node": "^16.13 || >=18"
+      }
+    },
+    "node_modules/@wdio/mocha-framework/node_modules/@wdio/types": {
+      "version": "8.32.2",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.32.2.tgz",
+      "integrity": "sha512-jq8LcBBQpBP9ZF5kECKEpXv8hN7irCGCjLFAN0Bd5ScRR6qu6MGWvwkDkau2sFPr0b++sKDCEaMzQlwrGFjZXg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "^20.1.0"
       },
       "engines": {
         "node": "^16.13 || >=18"
@@ -2590,27 +2460,6 @@
         "node": "^16.13 || >=18"
       }
     },
-    "node_modules/@wdio/runner/node_modules/@puppeteer/browsers": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.9.1.tgz",
-      "integrity": "sha512-PuvK6xZzGhKPvlx3fpfdM2kYY3P/hB1URtK8wA7XUJ6prn6pp22zvJHu48th0SGcHL9SutbPHrFuQgfXTFobWA==",
-      "dev": true,
-      "dependencies": {
-        "debug": "4.3.4",
-        "extract-zip": "2.0.1",
-        "progress": "2.0.3",
-        "proxy-agent": "6.3.1",
-        "tar-fs": "3.0.4",
-        "unbzip2-stream": "1.4.3",
-        "yargs": "17.7.2"
-      },
-      "bin": {
-        "browsers": "lib/cjs/main-cli.js"
-      },
-      "engines": {
-        "node": ">=16.3.0"
-      }
-    },
     "node_modules/@wdio/runner/node_modules/@wdio/types": {
       "version": "8.32.2",
       "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.32.2.tgz",
@@ -2621,58 +2470,6 @@
       },
       "engines": {
         "node": "^16.13 || >=18"
-      }
-    },
-    "node_modules/@wdio/runner/node_modules/@wdio/utils": {
-      "version": "8.32.3",
-      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-8.32.3.tgz",
-      "integrity": "sha512-UnR9rPpR1W9U5wz2TU+6BQ2rlxtuK/e3fvdaiWIMZKleB/OCcEQFGiGPAGGVi4ShfaTPwz6hK1cTTgj1OtMXkg==",
-      "dev": true,
-      "dependencies": {
-        "@puppeteer/browsers": "^1.6.0",
-        "@wdio/logger": "8.28.0",
-        "@wdio/types": "8.32.2",
-        "decamelize": "^6.0.0",
-        "deepmerge-ts": "^5.1.0",
-        "edgedriver": "^5.3.5",
-        "geckodriver": "^4.3.1",
-        "get-port": "^7.0.0",
-        "import-meta-resolve": "^4.0.0",
-        "locate-app": "^2.1.0",
-        "safaridriver": "^0.1.0",
-        "split2": "^4.2.0",
-        "wait-port": "^1.0.4"
-      },
-      "engines": {
-        "node": "^16.13 || >=18"
-      }
-    },
-    "node_modules/@wdio/runner/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@wdio/runner/node_modules/proxy-agent": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.1.tgz",
-      "integrity": "sha512-Rb5RVBy1iyqOtNl15Cw/llpeLH8bsb37gM1FUfKQ+Wck6xHlbAhWGUFiTRHtkjqGTA5pSHz6+0hrPW/oECihPQ==",
-      "dev": true,
-      "dependencies": {
-        "agent-base": "^7.0.2",
-        "debug": "^4.3.4",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.2",
-        "lru-cache": "^7.14.1",
-        "pac-proxy-agent": "^7.0.1",
-        "proxy-from-env": "^1.1.0",
-        "socks-proxy-agent": "^8.0.2"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/@wdio/spec-reporter": {
@@ -2704,14 +2501,13 @@
       }
     },
     "node_modules/@wdio/utils": {
-      "version": "8.31.1",
-      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-8.31.1.tgz",
-      "integrity": "sha512-fGUtNeJYSqPLMqIRrooEg1ViM2+z1Izd/7bzWzhg8EQHKFXqD/G68rEwBWpoLF/ziiHZFe4fJk7SZdXUK/gFgQ==",
-      "dev": true,
+      "version": "8.32.3",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-8.32.3.tgz",
+      "integrity": "sha512-UnR9rPpR1W9U5wz2TU+6BQ2rlxtuK/e3fvdaiWIMZKleB/OCcEQFGiGPAGGVi4ShfaTPwz6hK1cTTgj1OtMXkg==",
       "dependencies": {
         "@puppeteer/browsers": "^1.6.0",
         "@wdio/logger": "8.28.0",
-        "@wdio/types": "8.31.1",
+        "@wdio/types": "8.32.2",
         "decamelize": "^6.0.0",
         "deepmerge-ts": "^5.1.0",
         "edgedriver": "^5.3.5",
@@ -2731,7 +2527,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.9.1.tgz",
       "integrity": "sha512-PuvK6xZzGhKPvlx3fpfdM2kYY3P/hB1URtK8wA7XUJ6prn6pp22zvJHu48th0SGcHL9SutbPHrFuQgfXTFobWA==",
-      "dev": true,
       "dependencies": {
         "debug": "4.3.4",
         "extract-zip": "2.0.1",
@@ -2748,11 +2543,21 @@
         "node": ">=16.3.0"
       }
     },
+    "node_modules/@wdio/utils/node_modules/@wdio/types": {
+      "version": "8.32.2",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.32.2.tgz",
+      "integrity": "sha512-jq8LcBBQpBP9ZF5kECKEpXv8hN7irCGCjLFAN0Bd5ScRR6qu6MGWvwkDkau2sFPr0b++sKDCEaMzQlwrGFjZXg==",
+      "dependencies": {
+        "@types/node": "^20.1.0"
+      },
+      "engines": {
+        "node": "^16.13 || >=18"
+      }
+    },
     "node_modules/@wdio/utils/node_modules/lru-cache": {
       "version": "7.18.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
       "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -2761,7 +2566,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.1.tgz",
       "integrity": "sha512-Rb5RVBy1iyqOtNl15Cw/llpeLH8bsb37gM1FUfKQ+Wck6xHlbAhWGUFiTRHtkjqGTA5pSHz6+0hrPW/oECihPQ==",
-      "dev": true,
       "dependencies": {
         "agent-base": "^7.0.2",
         "debug": "^4.3.4",
@@ -12099,55 +11903,12 @@
         "node": "^16.13 || >=18"
       }
     },
-    "node_modules/webdriver/node_modules/@puppeteer/browsers": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.9.1.tgz",
-      "integrity": "sha512-PuvK6xZzGhKPvlx3fpfdM2kYY3P/hB1URtK8wA7XUJ6prn6pp22zvJHu48th0SGcHL9SutbPHrFuQgfXTFobWA==",
-      "dependencies": {
-        "debug": "4.3.4",
-        "extract-zip": "2.0.1",
-        "progress": "2.0.3",
-        "proxy-agent": "6.3.1",
-        "tar-fs": "3.0.4",
-        "unbzip2-stream": "1.4.3",
-        "yargs": "17.7.2"
-      },
-      "bin": {
-        "browsers": "lib/cjs/main-cli.js"
-      },
-      "engines": {
-        "node": ">=16.3.0"
-      }
-    },
     "node_modules/webdriver/node_modules/@wdio/types": {
       "version": "8.32.2",
       "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.32.2.tgz",
       "integrity": "sha512-jq8LcBBQpBP9ZF5kECKEpXv8hN7irCGCjLFAN0Bd5ScRR6qu6MGWvwkDkau2sFPr0b++sKDCEaMzQlwrGFjZXg==",
       "dependencies": {
         "@types/node": "^20.1.0"
-      },
-      "engines": {
-        "node": "^16.13 || >=18"
-      }
-    },
-    "node_modules/webdriver/node_modules/@wdio/utils": {
-      "version": "8.32.3",
-      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-8.32.3.tgz",
-      "integrity": "sha512-UnR9rPpR1W9U5wz2TU+6BQ2rlxtuK/e3fvdaiWIMZKleB/OCcEQFGiGPAGGVi4ShfaTPwz6hK1cTTgj1OtMXkg==",
-      "dependencies": {
-        "@puppeteer/browsers": "^1.6.0",
-        "@wdio/logger": "8.28.0",
-        "@wdio/types": "8.32.2",
-        "decamelize": "^6.0.0",
-        "deepmerge-ts": "^5.1.0",
-        "edgedriver": "^5.3.5",
-        "geckodriver": "^4.3.1",
-        "get-port": "^7.0.0",
-        "import-meta-resolve": "^4.0.0",
-        "locate-app": "^2.1.0",
-        "safaridriver": "^0.1.0",
-        "split2": "^4.2.0",
-        "wait-port": "^1.0.4"
       },
       "engines": {
         "node": "^16.13 || >=18"
@@ -12175,32 +11936,6 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/got?sponsor=1"
-      }
-    },
-    "node_modules/webdriver/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/webdriver/node_modules/proxy-agent": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.1.tgz",
-      "integrity": "sha512-Rb5RVBy1iyqOtNl15Cw/llpeLH8bsb37gM1FUfKQ+Wck6xHlbAhWGUFiTRHtkjqGTA5pSHz6+0hrPW/oECihPQ==",
-      "dependencies": {
-        "agent-base": "^7.0.2",
-        "debug": "^4.3.4",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.2",
-        "lru-cache": "^7.14.1",
-        "pac-proxy-agent": "^7.0.1",
-        "proxy-from-env": "^1.1.0",
-        "socks-proxy-agent": "^8.0.2"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/webdriverio": {
@@ -12245,26 +11980,6 @@
         }
       }
     },
-    "node_modules/webdriverio/node_modules/@puppeteer/browsers": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.9.1.tgz",
-      "integrity": "sha512-PuvK6xZzGhKPvlx3fpfdM2kYY3P/hB1URtK8wA7XUJ6prn6pp22zvJHu48th0SGcHL9SutbPHrFuQgfXTFobWA==",
-      "dependencies": {
-        "debug": "4.3.4",
-        "extract-zip": "2.0.1",
-        "progress": "2.0.3",
-        "proxy-agent": "6.3.1",
-        "tar-fs": "3.0.4",
-        "unbzip2-stream": "1.4.3",
-        "yargs": "17.7.2"
-      },
-      "bin": {
-        "browsers": "lib/cjs/main-cli.js"
-      },
-      "engines": {
-        "node": ">=16.3.0"
-      }
-    },
     "node_modules/webdriverio/node_modules/@wdio/types": {
       "version": "8.32.2",
       "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.32.2.tgz",
@@ -12276,43 +11991,12 @@
         "node": "^16.13 || >=18"
       }
     },
-    "node_modules/webdriverio/node_modules/@wdio/utils": {
-      "version": "8.32.3",
-      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-8.32.3.tgz",
-      "integrity": "sha512-UnR9rPpR1W9U5wz2TU+6BQ2rlxtuK/e3fvdaiWIMZKleB/OCcEQFGiGPAGGVi4ShfaTPwz6hK1cTTgj1OtMXkg==",
-      "dependencies": {
-        "@puppeteer/browsers": "^1.6.0",
-        "@wdio/logger": "8.28.0",
-        "@wdio/types": "8.32.2",
-        "decamelize": "^6.0.0",
-        "deepmerge-ts": "^5.1.0",
-        "edgedriver": "^5.3.5",
-        "geckodriver": "^4.3.1",
-        "get-port": "^7.0.0",
-        "import-meta-resolve": "^4.0.0",
-        "locate-app": "^2.1.0",
-        "safaridriver": "^0.1.0",
-        "split2": "^4.2.0",
-        "wait-port": "^1.0.4"
-      },
-      "engines": {
-        "node": "^16.13 || >=18"
-      }
-    },
     "node_modules/webdriverio/node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dependencies": {
         "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/webdriverio/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/webdriverio/node_modules/minimatch": {
@@ -12327,24 +12011,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/webdriverio/node_modules/proxy-agent": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.1.tgz",
-      "integrity": "sha512-Rb5RVBy1iyqOtNl15Cw/llpeLH8bsb37gM1FUfKQ+Wck6xHlbAhWGUFiTRHtkjqGTA5pSHz6+0hrPW/oECihPQ==",
-      "dependencies": {
-        "agent-base": "^7.0.2",
-        "debug": "^4.3.4",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.2",
-        "lru-cache": "^7.14.1",
-        "pac-proxy-agent": "^7.0.1",
-        "proxy-from-env": "^1.1.0",
-        "socks-proxy-agent": "^8.0.2"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@typescript-eslint/eslint-plugin": "^6.16.0",
         "@typescript-eslint/parser": "^6.16.0",
         "@wdio/cli": "^8.32.3",
-        "@wdio/local-runner": "^8.27.0",
+        "@wdio/local-runner": "^8.32.3",
         "@wdio/mocha-framework": "^8.27.0",
         "@wdio/spec-reporter": "^8.27.0",
         "@wdio/types": "^8.27.0",
@@ -2244,43 +2244,6 @@
         "node": ">=16.3.0"
       }
     },
-    "node_modules/@wdio/cli/node_modules/@wdio/config": {
-      "version": "8.32.3",
-      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-8.32.3.tgz",
-      "integrity": "sha512-hZkaz5Fd8830uniQvRgPus8yp9rp50MAsHa5kZ2Jt8y++Rp330FyJpQZE5oPjTATuz35G5Anprk2Q3fmFd0Ifw==",
-      "dev": true,
-      "dependencies": {
-        "@wdio/logger": "8.28.0",
-        "@wdio/types": "8.32.2",
-        "@wdio/utils": "8.32.3",
-        "decamelize": "^6.0.0",
-        "deepmerge-ts": "^5.0.0",
-        "glob": "^10.2.2",
-        "import-meta-resolve": "^4.0.0"
-      },
-      "engines": {
-        "node": "^16.13 || >=18"
-      }
-    },
-    "node_modules/@wdio/cli/node_modules/@wdio/globals": {
-      "version": "8.32.3",
-      "resolved": "https://registry.npmjs.org/@wdio/globals/-/globals-8.32.3.tgz",
-      "integrity": "sha512-jyK89GvWaOYQT9pfZ6HNwkFANgai9eBVfeDPw5yFLXfk6js9GSWbvqMJg/PFi1dQ7xbnbuuf5eYVc65bfAt9KQ==",
-      "dev": true,
-      "engines": {
-        "node": "^16.13 || >=18"
-      },
-      "optionalDependencies": {
-        "expect-webdriverio": "^4.11.2",
-        "webdriverio": "8.32.3"
-      }
-    },
-    "node_modules/@wdio/cli/node_modules/@wdio/protocols": {
-      "version": "8.32.0",
-      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-8.32.0.tgz",
-      "integrity": "sha512-inLJRrtIGdTz/YPbcsvpSvPlYQFTVtF3OYBwAXhG2FiP1ZwE1CQNLP/xgRGye1ymdGCypGkexRqIx3KBGm801Q==",
-      "dev": true
-    },
     "node_modules/@wdio/cli/node_modules/@wdio/types": {
       "version": "8.32.2",
       "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.32.2.tgz",
@@ -2315,15 +2278,6 @@
       },
       "engines": {
         "node": "^16.13 || >=18"
-      }
-    },
-    "node_modules/@wdio/cli/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@wdio/cli/node_modules/execa": {
@@ -2361,43 +2315,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@wdio/cli/node_modules/got": {
-      "version": "12.6.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-12.6.1.tgz",
-      "integrity": "sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==",
-      "dev": true,
-      "dependencies": {
-        "@sindresorhus/is": "^5.2.0",
-        "@szmarczak/http-timer": "^5.0.1",
-        "cacheable-lookup": "^7.0.0",
-        "cacheable-request": "^10.2.8",
-        "decompress-response": "^6.0.0",
-        "form-data-encoder": "^2.1.2",
-        "get-stream": "^6.0.1",
-        "http2-wrapper": "^2.1.10",
-        "lowercase-keys": "^3.0.0",
-        "p-cancelable": "^3.0.0",
-        "responselike": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/got?sponsor=1"
-      }
-    },
-    "node_modules/@wdio/cli/node_modules/got/node_modules/get-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@wdio/cli/node_modules/human-signals": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
@@ -2414,21 +2331,6 @@
       "dev": true,
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@wdio/cli/node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@wdio/cli/node_modules/proxy-agent": {
@@ -2462,79 +2364,14 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@wdio/cli/node_modules/webdriver": {
-      "version": "8.32.3",
-      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-8.32.3.tgz",
-      "integrity": "sha512-1/kpZvuftt59oikHs+6FvWXNfOM5tgMMMAk3LnMe7D938dVOoNGAe46fq0oL/xsxxPicbMRTRgIy1OifLiglaA==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "^20.1.0",
-        "@types/ws": "^8.5.3",
-        "@wdio/config": "8.32.3",
-        "@wdio/logger": "8.28.0",
-        "@wdio/protocols": "8.32.0",
-        "@wdio/types": "8.32.2",
-        "@wdio/utils": "8.32.3",
-        "deepmerge-ts": "^5.1.0",
-        "got": "^12.6.1",
-        "ky": "^0.33.0",
-        "ws": "^8.8.0"
-      },
-      "engines": {
-        "node": "^16.13 || >=18"
-      }
-    },
-    "node_modules/@wdio/cli/node_modules/webdriverio": {
-      "version": "8.32.3",
-      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-8.32.3.tgz",
-      "integrity": "sha512-SupbQKMtUZHSH7lmF5xaJPgxsn8sIBNAjs1CyPI33u30eY9VcVQ4CJQ818ZS3FLxR0q2XdWk9lsQNyhZwlN3RA==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "^20.1.0",
-        "@wdio/config": "8.32.3",
-        "@wdio/logger": "8.28.0",
-        "@wdio/protocols": "8.32.0",
-        "@wdio/repl": "8.24.12",
-        "@wdio/types": "8.32.2",
-        "@wdio/utils": "8.32.3",
-        "archiver": "^6.0.0",
-        "aria-query": "^5.0.0",
-        "css-shorthand-properties": "^1.1.1",
-        "css-value": "^0.0.1",
-        "devtools-protocol": "^0.0.1262051",
-        "grapheme-splitter": "^1.0.2",
-        "import-meta-resolve": "^4.0.0",
-        "is-plain-obj": "^4.1.0",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.zip": "^4.2.0",
-        "minimatch": "^9.0.0",
-        "puppeteer-core": "^20.9.0",
-        "query-selector-shadow-dom": "^1.0.0",
-        "resq": "^1.9.1",
-        "rgb2hex": "0.2.5",
-        "serialize-error": "^11.0.1",
-        "webdriver": "8.32.3"
-      },
-      "engines": {
-        "node": "^16.13 || >=18"
-      },
-      "peerDependencies": {
-        "devtools": "^8.14.0"
-      },
-      "peerDependenciesMeta": {
-        "devtools": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@wdio/config": {
-      "version": "8.31.1",
-      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-8.31.1.tgz",
-      "integrity": "sha512-Iz4DTXQdy53VT8LRZ6ayaDKE+zEDk4QY/ILz+D0IQh0OaMWruFesfoxqFP0hnU6rbJT1YE4ehTGf7JTZLWIPcw==",
+      "version": "8.32.3",
+      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-8.32.3.tgz",
+      "integrity": "sha512-hZkaz5Fd8830uniQvRgPus8yp9rp50MAsHa5kZ2Jt8y++Rp330FyJpQZE5oPjTATuz35G5Anprk2Q3fmFd0Ifw==",
       "dependencies": {
         "@wdio/logger": "8.28.0",
-        "@wdio/types": "8.31.1",
-        "@wdio/utils": "8.31.1",
+        "@wdio/types": "8.32.2",
+        "@wdio/utils": "8.32.3",
         "decamelize": "^6.0.0",
         "deepmerge-ts": "^5.0.0",
         "glob": "^10.2.2",
@@ -2544,33 +2381,125 @@
         "node": "^16.13 || >=18"
       }
     },
+    "node_modules/@wdio/config/node_modules/@puppeteer/browsers": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.9.1.tgz",
+      "integrity": "sha512-PuvK6xZzGhKPvlx3fpfdM2kYY3P/hB1URtK8wA7XUJ6prn6pp22zvJHu48th0SGcHL9SutbPHrFuQgfXTFobWA==",
+      "dependencies": {
+        "debug": "4.3.4",
+        "extract-zip": "2.0.1",
+        "progress": "2.0.3",
+        "proxy-agent": "6.3.1",
+        "tar-fs": "3.0.4",
+        "unbzip2-stream": "1.4.3",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=16.3.0"
+      }
+    },
+    "node_modules/@wdio/config/node_modules/@wdio/types": {
+      "version": "8.32.2",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.32.2.tgz",
+      "integrity": "sha512-jq8LcBBQpBP9ZF5kECKEpXv8hN7irCGCjLFAN0Bd5ScRR6qu6MGWvwkDkau2sFPr0b++sKDCEaMzQlwrGFjZXg==",
+      "dependencies": {
+        "@types/node": "^20.1.0"
+      },
+      "engines": {
+        "node": "^16.13 || >=18"
+      }
+    },
+    "node_modules/@wdio/config/node_modules/@wdio/utils": {
+      "version": "8.32.3",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-8.32.3.tgz",
+      "integrity": "sha512-UnR9rPpR1W9U5wz2TU+6BQ2rlxtuK/e3fvdaiWIMZKleB/OCcEQFGiGPAGGVi4ShfaTPwz6hK1cTTgj1OtMXkg==",
+      "dependencies": {
+        "@puppeteer/browsers": "^1.6.0",
+        "@wdio/logger": "8.28.0",
+        "@wdio/types": "8.32.2",
+        "decamelize": "^6.0.0",
+        "deepmerge-ts": "^5.1.0",
+        "edgedriver": "^5.3.5",
+        "geckodriver": "^4.3.1",
+        "get-port": "^7.0.0",
+        "import-meta-resolve": "^4.0.0",
+        "locate-app": "^2.1.0",
+        "safaridriver": "^0.1.0",
+        "split2": "^4.2.0",
+        "wait-port": "^1.0.4"
+      },
+      "engines": {
+        "node": "^16.13 || >=18"
+      }
+    },
+    "node_modules/@wdio/config/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wdio/config/node_modules/proxy-agent": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.1.tgz",
+      "integrity": "sha512-Rb5RVBy1iyqOtNl15Cw/llpeLH8bsb37gM1FUfKQ+Wck6xHlbAhWGUFiTRHtkjqGTA5pSHz6+0hrPW/oECihPQ==",
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.2",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.0.1",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/@wdio/globals": {
-      "version": "8.31.1",
-      "resolved": "https://registry.npmjs.org/@wdio/globals/-/globals-8.31.1.tgz",
-      "integrity": "sha512-2r80BX8aS5YiQ6cFuxtt44g2Y5P01MoHJTR3w21suSyiVoH70mxvJf6vJsLB+jtGfaXLJzOjlZkgXrd+Kn+keA==",
+      "version": "8.32.3",
+      "resolved": "https://registry.npmjs.org/@wdio/globals/-/globals-8.32.3.tgz",
+      "integrity": "sha512-jyK89GvWaOYQT9pfZ6HNwkFANgai9eBVfeDPw5yFLXfk6js9GSWbvqMJg/PFi1dQ7xbnbuuf5eYVc65bfAt9KQ==",
       "dev": true,
       "engines": {
         "node": "^16.13 || >=18"
       },
       "optionalDependencies": {
         "expect-webdriverio": "^4.11.2",
-        "webdriverio": "8.31.1"
+        "webdriverio": "8.32.3"
       }
     },
     "node_modules/@wdio/local-runner": {
-      "version": "8.31.1",
-      "resolved": "https://registry.npmjs.org/@wdio/local-runner/-/local-runner-8.31.1.tgz",
-      "integrity": "sha512-KaMok/LaVvWcXTTi61Al5+XgocBDJ2+gpG1mjxytILrwaMFohYL0YuaGDw4yb3lx3Lsej6K+/FbaWMMnGq3JIw==",
+      "version": "8.32.3",
+      "resolved": "https://registry.npmjs.org/@wdio/local-runner/-/local-runner-8.32.3.tgz",
+      "integrity": "sha512-YgqYkKarx2m9OjA8WO4NqQPCfFNLmZHnuEWQ6P2LqUeYFsdXRd3wR3UTo9XrI23VSQo+kcpqInsR5vLOYDd1zg==",
       "dev": true,
       "dependencies": {
         "@types/node": "^20.1.0",
         "@wdio/logger": "8.28.0",
         "@wdio/repl": "8.24.12",
-        "@wdio/runner": "8.31.1",
-        "@wdio/types": "8.31.1",
+        "@wdio/runner": "8.32.3",
+        "@wdio/types": "8.32.2",
         "async-exit-hook": "^2.0.1",
         "split2": "^4.1.0",
         "stream-buffers": "^3.0.2"
+      },
+      "engines": {
+        "node": "^16.13 || >=18"
+      }
+    },
+    "node_modules/@wdio/local-runner/node_modules/@wdio/types": {
+      "version": "8.32.2",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.32.2.tgz",
+      "integrity": "sha512-jq8LcBBQpBP9ZF5kECKEpXv8hN7irCGCjLFAN0Bd5ScRR6qu6MGWvwkDkau2sFPr0b++sKDCEaMzQlwrGFjZXg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "^20.1.0"
       },
       "engines": {
         "node": "^16.13 || >=18"
@@ -2608,9 +2537,9 @@
       }
     },
     "node_modules/@wdio/protocols": {
-      "version": "8.29.7",
-      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-8.29.7.tgz",
-      "integrity": "sha512-9hhEePMLmI8fm9F2v4jlg9x4w4jEoZmY3vT6fXy90ne1DFaGWfy/a853nKEagQe/ZzxkN3/cpMBh8mryv9BVjw=="
+      "version": "8.32.0",
+      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-8.32.0.tgz",
+      "integrity": "sha512-inLJRrtIGdTz/YPbcsvpSvPlYQFTVtF3OYBwAXhG2FiP1ZwE1CQNLP/xgRGye1ymdGCypGkexRqIx3KBGm801Q=="
     },
     "node_modules/@wdio/repl": {
       "version": "8.24.12",
@@ -2640,25 +2569,110 @@
       }
     },
     "node_modules/@wdio/runner": {
-      "version": "8.31.1",
-      "resolved": "https://registry.npmjs.org/@wdio/runner/-/runner-8.31.1.tgz",
-      "integrity": "sha512-9KUDaAHNUeBp5h1YoEmKVk0hZyzBDl6x0ge1dnaORACKKi6TXa76T0kLaBruuBTBn4zZd4+Xrg9/bLGAnTFvLA==",
+      "version": "8.32.3",
+      "resolved": "https://registry.npmjs.org/@wdio/runner/-/runner-8.32.3.tgz",
+      "integrity": "sha512-HlhdQ4lJ07seL7/x0UQPDnK+o5a0okyjd8ukFYqDL+g9+d3KlW/oM3NvFfX7pb9liIYNEpmoNMwKFp+5XPUE7w==",
       "dev": true,
       "dependencies": {
         "@types/node": "^20.1.0",
-        "@wdio/config": "8.31.1",
-        "@wdio/globals": "8.31.1",
+        "@wdio/config": "8.32.3",
+        "@wdio/globals": "8.32.3",
         "@wdio/logger": "8.28.0",
-        "@wdio/types": "8.31.1",
-        "@wdio/utils": "8.31.1",
+        "@wdio/types": "8.32.2",
+        "@wdio/utils": "8.32.3",
         "deepmerge-ts": "^5.0.0",
         "expect-webdriverio": "^4.11.2",
         "gaze": "^1.1.2",
-        "webdriver": "8.31.1",
-        "webdriverio": "8.31.1"
+        "webdriver": "8.32.3",
+        "webdriverio": "8.32.3"
       },
       "engines": {
         "node": "^16.13 || >=18"
+      }
+    },
+    "node_modules/@wdio/runner/node_modules/@puppeteer/browsers": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.9.1.tgz",
+      "integrity": "sha512-PuvK6xZzGhKPvlx3fpfdM2kYY3P/hB1URtK8wA7XUJ6prn6pp22zvJHu48th0SGcHL9SutbPHrFuQgfXTFobWA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "4.3.4",
+        "extract-zip": "2.0.1",
+        "progress": "2.0.3",
+        "proxy-agent": "6.3.1",
+        "tar-fs": "3.0.4",
+        "unbzip2-stream": "1.4.3",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=16.3.0"
+      }
+    },
+    "node_modules/@wdio/runner/node_modules/@wdio/types": {
+      "version": "8.32.2",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.32.2.tgz",
+      "integrity": "sha512-jq8LcBBQpBP9ZF5kECKEpXv8hN7irCGCjLFAN0Bd5ScRR6qu6MGWvwkDkau2sFPr0b++sKDCEaMzQlwrGFjZXg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "^20.1.0"
+      },
+      "engines": {
+        "node": "^16.13 || >=18"
+      }
+    },
+    "node_modules/@wdio/runner/node_modules/@wdio/utils": {
+      "version": "8.32.3",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-8.32.3.tgz",
+      "integrity": "sha512-UnR9rPpR1W9U5wz2TU+6BQ2rlxtuK/e3fvdaiWIMZKleB/OCcEQFGiGPAGGVi4ShfaTPwz6hK1cTTgj1OtMXkg==",
+      "dev": true,
+      "dependencies": {
+        "@puppeteer/browsers": "^1.6.0",
+        "@wdio/logger": "8.28.0",
+        "@wdio/types": "8.32.2",
+        "decamelize": "^6.0.0",
+        "deepmerge-ts": "^5.1.0",
+        "edgedriver": "^5.3.5",
+        "geckodriver": "^4.3.1",
+        "get-port": "^7.0.0",
+        "import-meta-resolve": "^4.0.0",
+        "locate-app": "^2.1.0",
+        "safaridriver": "^0.1.0",
+        "split2": "^4.2.0",
+        "wait-port": "^1.0.4"
+      },
+      "engines": {
+        "node": "^16.13 || >=18"
+      }
+    },
+    "node_modules/@wdio/runner/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wdio/runner/node_modules/proxy-agent": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.1.tgz",
+      "integrity": "sha512-Rb5RVBy1iyqOtNl15Cw/llpeLH8bsb37gM1FUfKQ+Wck6xHlbAhWGUFiTRHtkjqGTA5pSHz6+0hrPW/oECihPQ==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.2",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.0.1",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/@wdio/spec-reporter": {
@@ -2681,6 +2695,7 @@
       "version": "8.31.1",
       "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.31.1.tgz",
       "integrity": "sha512-KQ0EmjeVdshufhsxygaPzkJ8WD7hm8WlflZcLwKMZ0OM6f8pV9NMGGOvfBQXgTs447ScK6/6rX+lbJk3yvg65g==",
+      "dev": true,
       "dependencies": {
         "@types/node": "^20.1.0"
       },
@@ -2692,6 +2707,7 @@
       "version": "8.31.1",
       "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-8.31.1.tgz",
       "integrity": "sha512-fGUtNeJYSqPLMqIRrooEg1ViM2+z1Izd/7bzWzhg8EQHKFXqD/G68rEwBWpoLF/ziiHZFe4fJk7SZdXUK/gFgQ==",
+      "dev": true,
       "dependencies": {
         "@puppeteer/browsers": "^1.6.0",
         "@wdio/logger": "8.28.0",
@@ -2715,6 +2731,7 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.9.1.tgz",
       "integrity": "sha512-PuvK6xZzGhKPvlx3fpfdM2kYY3P/hB1URtK8wA7XUJ6prn6pp22zvJHu48th0SGcHL9SutbPHrFuQgfXTFobWA==",
+      "dev": true,
       "dependencies": {
         "debug": "4.3.4",
         "extract-zip": "2.0.1",
@@ -2735,6 +2752,7 @@
       "version": "7.18.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
       "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -2743,6 +2761,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.1.tgz",
       "integrity": "sha512-Rb5RVBy1iyqOtNl15Cw/llpeLH8bsb37gM1FUfKQ+Wck6xHlbAhWGUFiTRHtkjqGTA5pSHz6+0hrPW/oECihPQ==",
+      "dev": true,
       "dependencies": {
         "agent-base": "^7.0.2",
         "debug": "^4.3.4",
@@ -12060,21 +12079,75 @@
       }
     },
     "node_modules/webdriver": {
-      "version": "8.31.1",
-      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-8.31.1.tgz",
-      "integrity": "sha512-J1Ata+ZiBVhCFKL7hnD6qCfr7ZRsBN2c/YlCgosq0lG/iYMKXWi5rlWDfpuyISprM/G/V3GjfEGxTUC6jJBSBA==",
+      "version": "8.32.3",
+      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-8.32.3.tgz",
+      "integrity": "sha512-1/kpZvuftt59oikHs+6FvWXNfOM5tgMMMAk3LnMe7D938dVOoNGAe46fq0oL/xsxxPicbMRTRgIy1OifLiglaA==",
       "dependencies": {
         "@types/node": "^20.1.0",
         "@types/ws": "^8.5.3",
-        "@wdio/config": "8.31.1",
+        "@wdio/config": "8.32.3",
         "@wdio/logger": "8.28.0",
-        "@wdio/protocols": "8.29.7",
-        "@wdio/types": "8.31.1",
-        "@wdio/utils": "8.31.1",
+        "@wdio/protocols": "8.32.0",
+        "@wdio/types": "8.32.2",
+        "@wdio/utils": "8.32.3",
         "deepmerge-ts": "^5.1.0",
         "got": "^12.6.1",
         "ky": "^0.33.0",
         "ws": "^8.8.0"
+      },
+      "engines": {
+        "node": "^16.13 || >=18"
+      }
+    },
+    "node_modules/webdriver/node_modules/@puppeteer/browsers": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.9.1.tgz",
+      "integrity": "sha512-PuvK6xZzGhKPvlx3fpfdM2kYY3P/hB1URtK8wA7XUJ6prn6pp22zvJHu48th0SGcHL9SutbPHrFuQgfXTFobWA==",
+      "dependencies": {
+        "debug": "4.3.4",
+        "extract-zip": "2.0.1",
+        "progress": "2.0.3",
+        "proxy-agent": "6.3.1",
+        "tar-fs": "3.0.4",
+        "unbzip2-stream": "1.4.3",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=16.3.0"
+      }
+    },
+    "node_modules/webdriver/node_modules/@wdio/types": {
+      "version": "8.32.2",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.32.2.tgz",
+      "integrity": "sha512-jq8LcBBQpBP9ZF5kECKEpXv8hN7irCGCjLFAN0Bd5ScRR6qu6MGWvwkDkau2sFPr0b++sKDCEaMzQlwrGFjZXg==",
+      "dependencies": {
+        "@types/node": "^20.1.0"
+      },
+      "engines": {
+        "node": "^16.13 || >=18"
+      }
+    },
+    "node_modules/webdriver/node_modules/@wdio/utils": {
+      "version": "8.32.3",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-8.32.3.tgz",
+      "integrity": "sha512-UnR9rPpR1W9U5wz2TU+6BQ2rlxtuK/e3fvdaiWIMZKleB/OCcEQFGiGPAGGVi4ShfaTPwz6hK1cTTgj1OtMXkg==",
+      "dependencies": {
+        "@puppeteer/browsers": "^1.6.0",
+        "@wdio/logger": "8.28.0",
+        "@wdio/types": "8.32.2",
+        "decamelize": "^6.0.0",
+        "deepmerge-ts": "^5.1.0",
+        "edgedriver": "^5.3.5",
+        "geckodriver": "^4.3.1",
+        "get-port": "^7.0.0",
+        "import-meta-resolve": "^4.0.0",
+        "locate-app": "^2.1.0",
+        "safaridriver": "^0.1.0",
+        "split2": "^4.2.0",
+        "wait-port": "^1.0.4"
       },
       "engines": {
         "node": "^16.13 || >=18"
@@ -12104,23 +12177,49 @@
         "url": "https://github.com/sindresorhus/got?sponsor=1"
       }
     },
+    "node_modules/webdriver/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/webdriver/node_modules/proxy-agent": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.1.tgz",
+      "integrity": "sha512-Rb5RVBy1iyqOtNl15Cw/llpeLH8bsb37gM1FUfKQ+Wck6xHlbAhWGUFiTRHtkjqGTA5pSHz6+0hrPW/oECihPQ==",
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.2",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.0.1",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/webdriverio": {
-      "version": "8.31.1",
-      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-8.31.1.tgz",
-      "integrity": "sha512-b3bLBkkSGESGcRw3s3Sty84luZe2+qwPudXosSXbzcRu2Z1sccjdA6BHJA36IcLgKndNCOhf9wx3yQ3umoS7Jw==",
+      "version": "8.32.3",
+      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-8.32.3.tgz",
+      "integrity": "sha512-SupbQKMtUZHSH7lmF5xaJPgxsn8sIBNAjs1CyPI33u30eY9VcVQ4CJQ818ZS3FLxR0q2XdWk9lsQNyhZwlN3RA==",
       "dependencies": {
         "@types/node": "^20.1.0",
-        "@wdio/config": "8.31.1",
+        "@wdio/config": "8.32.3",
         "@wdio/logger": "8.28.0",
-        "@wdio/protocols": "8.29.7",
+        "@wdio/protocols": "8.32.0",
         "@wdio/repl": "8.24.12",
-        "@wdio/types": "8.31.1",
-        "@wdio/utils": "8.31.1",
+        "@wdio/types": "8.32.2",
+        "@wdio/utils": "8.32.3",
         "archiver": "^6.0.0",
         "aria-query": "^5.0.0",
         "css-shorthand-properties": "^1.1.1",
         "css-value": "^0.0.1",
-        "devtools-protocol": "^0.0.1255431",
+        "devtools-protocol": "^0.0.1262051",
         "grapheme-splitter": "^1.0.2",
         "import-meta-resolve": "^4.0.0",
         "is-plain-obj": "^4.1.0",
@@ -12132,7 +12231,7 @@
         "resq": "^1.9.1",
         "rgb2hex": "0.2.5",
         "serialize-error": "^11.0.1",
-        "webdriver": "8.31.1"
+        "webdriver": "8.32.3"
       },
       "engines": {
         "node": "^16.13 || >=18"
@@ -12146,6 +12245,60 @@
         }
       }
     },
+    "node_modules/webdriverio/node_modules/@puppeteer/browsers": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.9.1.tgz",
+      "integrity": "sha512-PuvK6xZzGhKPvlx3fpfdM2kYY3P/hB1URtK8wA7XUJ6prn6pp22zvJHu48th0SGcHL9SutbPHrFuQgfXTFobWA==",
+      "dependencies": {
+        "debug": "4.3.4",
+        "extract-zip": "2.0.1",
+        "progress": "2.0.3",
+        "proxy-agent": "6.3.1",
+        "tar-fs": "3.0.4",
+        "unbzip2-stream": "1.4.3",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=16.3.0"
+      }
+    },
+    "node_modules/webdriverio/node_modules/@wdio/types": {
+      "version": "8.32.2",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.32.2.tgz",
+      "integrity": "sha512-jq8LcBBQpBP9ZF5kECKEpXv8hN7irCGCjLFAN0Bd5ScRR6qu6MGWvwkDkau2sFPr0b++sKDCEaMzQlwrGFjZXg==",
+      "dependencies": {
+        "@types/node": "^20.1.0"
+      },
+      "engines": {
+        "node": "^16.13 || >=18"
+      }
+    },
+    "node_modules/webdriverio/node_modules/@wdio/utils": {
+      "version": "8.32.3",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-8.32.3.tgz",
+      "integrity": "sha512-UnR9rPpR1W9U5wz2TU+6BQ2rlxtuK/e3fvdaiWIMZKleB/OCcEQFGiGPAGGVi4ShfaTPwz6hK1cTTgj1OtMXkg==",
+      "dependencies": {
+        "@puppeteer/browsers": "^1.6.0",
+        "@wdio/logger": "8.28.0",
+        "@wdio/types": "8.32.2",
+        "decamelize": "^6.0.0",
+        "deepmerge-ts": "^5.1.0",
+        "edgedriver": "^5.3.5",
+        "geckodriver": "^4.3.1",
+        "get-port": "^7.0.0",
+        "import-meta-resolve": "^4.0.0",
+        "locate-app": "^2.1.0",
+        "safaridriver": "^0.1.0",
+        "split2": "^4.2.0",
+        "wait-port": "^1.0.4"
+      },
+      "engines": {
+        "node": "^16.13 || >=18"
+      }
+    },
     "node_modules/webdriverio/node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -12154,10 +12307,13 @@
         "balanced-match": "^1.0.0"
       }
     },
-    "node_modules/webdriverio/node_modules/devtools-protocol": {
-      "version": "0.0.1255431",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1255431.tgz",
-      "integrity": "sha512-VuKgO1U4Ew4meKKoXCEBMUNkzyQqci5F8HIuoELPJkr5yvk9kR9p07gaZfzG9QIIrcIfpJVgf6Ms8OqEMxEYgA=="
+    "node_modules/webdriverio/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/webdriverio/node_modules/minimatch": {
       "version": "9.0.3",
@@ -12171,6 +12327,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/webdriverio/node_modules/proxy-agent": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.1.tgz",
+      "integrity": "sha512-Rb5RVBy1iyqOtNl15Cw/llpeLH8bsb37gM1FUfKQ+Wck6xHlbAhWGUFiTRHtkjqGTA5pSHz6+0hrPW/oECihPQ==",
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.2",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.0.1",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@wdio/cli": "^8.32.3",
     "@wdio/local-runner": "^8.32.3",
     "@wdio/mocha-framework": "^8.32.3",
-    "@wdio/spec-reporter": "^8.27.0",
+    "@wdio/spec-reporter": "^8.32.2",
     "@wdio/types": "^8.27.0",
     "eslint": "^8.56.0",
     "eslint-config-airbnb-base": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@types/node": "^20.10.5",
     "@typescript-eslint/eslint-plugin": "^6.16.0",
     "@typescript-eslint/parser": "^6.16.0",
-    "@wdio/cli": "^8.27.0",
+    "@wdio/cli": "^8.32.3",
     "@wdio/local-runner": "^8.27.0",
     "@wdio/mocha-framework": "^8.27.0",
     "@wdio/spec-reporter": "^8.27.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@typescript-eslint/eslint-plugin": "^6.16.0",
     "@typescript-eslint/parser": "^6.16.0",
     "@wdio/cli": "^8.32.3",
-    "@wdio/local-runner": "^8.27.0",
+    "@wdio/local-runner": "^8.32.3",
     "@wdio/mocha-framework": "^8.27.0",
     "@wdio/spec-reporter": "^8.27.0",
     "@wdio/types": "^8.27.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@typescript-eslint/parser": "^6.16.0",
     "@wdio/cli": "^8.32.3",
     "@wdio/local-runner": "^8.32.3",
-    "@wdio/mocha-framework": "^8.27.0",
+    "@wdio/mocha-framework": "^8.32.3",
     "@wdio/spec-reporter": "^8.27.0",
     "@wdio/types": "^8.27.0",
     "eslint": "^8.56.0",


### PR DESCRIPTION
### Proposed Changes

- ﻿Bump @wdio/cli from 8.31.1 to 8.32.3
- Bump @wdio/local-runner from 8.31.1 to 8.32.3
- Bump @wdio/mocha-framework from 8.31.1 to 8.32.3
- Bump @wdio/spec-reporter from 8.31.1 to 8.32.2